### PR TITLE
MPEG2DecPlus buildable under linux too

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.1)
+
+set(ProjectName "MPEG2DecPlus")
+
+project(${ProjectName} LANGUAGES CXX)
+
+string(TOLOWER "${ProjectName}" LibName)
+
+find_path(AVS_FOUND avisynth.h HINTS /usr/include /usr/local/include PATH_SUFFIXES avisynth)
+if (NOT AVS_FOUND)
+    message(FATAL_ERROR "AviSynth+ not found.")
+else()
+    message(STATUS "AviSynth+ : ${AVS_FOUND}")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fPIC -std=c++17 -I${AVS_FOUND} ")
+
+#include_directories("include/")
+
+file(GLOB SOURCES "../src/*.cpp")
+
+# special SSE2 option for source files with *_sse2.cpp pattern
+file(GLOB_RECURSE SRCS_SSE2 "../src/*_sse2.cpp")
+set_source_files_properties(${SRCS_SSE2} PROPERTIES COMPILE_FLAGS " -msse2 ")
+
+# special SSSE3 option for source files with *_sse3.cpp pattern
+file(GLOB_RECURSE SRCS_SSSE3 "../src/*_sse3.cpp")
+set_source_files_properties(${SRCS_SSSE3} PROPERTIES COMPILE_FLAGS " -msse3 ")
+
+# special AVX2 option for source files with *_avx2.cpp pattern
+file(GLOB_RECURSE SRCS_AVX2 "../src/*_avx2.cpp")
+set_source_files_properties(${SRCS_AVX2} PROPERTIES COMPILE_FLAGS " -mavx2 -mfma ")
+
+add_library("${LibName}" SHARED ${SOURCES})
+
+# I won't worry about installation ATM
+#install(TARGETS mpeg2decplus DESTINATION /usr/local/lib)
+

--- a/src/AVISynthAPI.cpp
+++ b/src/AVISynthAPI.cpp
@@ -185,12 +185,20 @@ MPEG2Source::MPEG2Source(const char* d2v, int idct, bool showQ,
         env->ThrowError("MPEG2Source: iDCT invalid (1:MMX,2:SSEMMX,3:SSE2,4:FPU,5:REF,6:Skal's,7:Simple)");
 
     FILE* f;
+#ifdef _WIN32
     fopen_s(&f, d2v, "r");
+#else
+    f = fopen(d2v, "r");
+#endif
     if (f == nullptr)
         env->ThrowError("MPEG2Source: unable to load D2V file \"%s\" ", d2v);
 
     try {
+#ifdef _WIN32
         decoder = new CMPEG2Decoder(f, d2v, idct, iCC, _upConv, _info, showQ, _i420);
+#else
+        decoder = new CMPEG2Decoder(f, d2v, idct, iCC, _upConv, _info, showQ, _i420, env->GetCPUFlags());
+#endif
     }
     catch (std::runtime_error& e) {
         if (f) fclose(f);
@@ -416,7 +424,11 @@ AVSValue __cdecl MPEG2Source::create(AVSValue args, void*, IScriptEnvironment* e
     bool i420 = false;
 
     FILE* def;
+#ifdef _WIN32
     fopen_s(&def, "MPEG2DecPlus.def", "r");
+#else
+    def = fopen("MPEG2DecPlus.def", "r");
+#endif
     if (def != nullptr) {
         set_user_default(def, d2v, idct, showQ, info, upConv, i420, iCC);
         fclose(def);

--- a/src/AVISynthAPI.h
+++ b/src/AVISynthAPI.h
@@ -28,7 +28,11 @@
 
 #include <cstdint>
 #include <avisynth.h>
+#ifdef _WIN32
 #include <avs/win.h>
+#else
+#include "win_import_min.h"
+#endif
 #include "MPEG2Decoder.h"
 
 

--- a/src/MPEG2Decoder.h
+++ b/src/MPEG2Decoder.h
@@ -7,13 +7,19 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#ifdef _WIN32
 #include <io.h>
+#endif
 #include <fcntl.h>
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
 #include <winreg.h>
+#else
+#include "win_import_min.h"
+#endif
 
 #include "yv12pict.h"
 
@@ -329,7 +335,11 @@ class CMPEG2Decoder
 
 public:
     CMPEG2Decoder(FILE* file, const char* path, int _idct, int icc, int upconv,
+#ifdef _WIN32
                   int info, bool showq, bool _i420);
+#else
+                  int info, bool showq, bool _i420, int _cpu_flags);
+#endif
     ~CMPEG2Decoder() { destroy(); }
     void Decode(uint32_t frame, YV12PICT& dst);
 
@@ -370,6 +380,9 @@ public:
     int getChromaWidth() { return Chroma_Width; }
     int getLumaWidth() { return Coded_Picture_Width; }
     int getLumaHeight() { return Coded_Picture_Height; }
+#ifndef _WIN32
+    int cpu_flags;
+#endif
 };
 
 

--- a/src/color_convert.cpp
+++ b/src/color_convert.cpp
@@ -16,6 +16,9 @@ MPEG2Dec's colorspace convertions Copyright (C) Chia-chen Kuo - April 2001
 
 #include <cstring>
 #include <emmintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "color_convert.h"
 
 

--- a/src/idct_ap922_sse2.cpp
+++ b/src/idct_ap922_sse2.cpp
@@ -82,6 +82,9 @@ These examples contain code fragments for first stage iDCT 8x8
 
 #include <cstdint>
 #include <emmintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 
 
 alignas(64) static const int16_t table04[] = {

--- a/src/idct_llm_float_avx2.cpp
+++ b/src/idct_llm_float_avx2.cpp
@@ -3,6 +3,9 @@
 #endif
 
 #include <immintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "idct.h"
 
 alignas(64) static const float llm_coefs[] = {

--- a/src/idct_llm_float_sse2.cpp
+++ b/src/idct_llm_float_sse2.cpp
@@ -1,4 +1,7 @@
 #include <emmintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "idct.h"
 
 

--- a/src/idct_ref_sse3.cpp
+++ b/src/idct_ref_sse3.cpp
@@ -8,6 +8,9 @@ OKA Motofumi - August 29, 2016
 
 
 #include <pmmintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "idct.h"
 
 /*  Perform IEEE 1180 reference (64-bit floating point, separable 8x1

--- a/src/mc.cpp
+++ b/src/mc.cpp
@@ -27,6 +27,9 @@
 
 
 #include <emmintrin.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "mc.h"
 
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -23,11 +23,15 @@
 
 
 #include <cstdio>
+#ifdef _WIN32
 #include <intrin.h>
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-
+#else
+#include <avisynth.h>
+#include "win_import_min.h"
+#endif
 #include "misc.h"
 
 
@@ -38,7 +42,7 @@ size_t __cdecl dprintf(char* fmt, ...)
     va_list argp;
 
     va_start(argp, fmt);
-    vsprintf_s(printString, fmt, argp);
+    vsprintf_s(printString, 1024, fmt, argp);
     va_end(argp);
     OutputDebugString(printString);
     return strlen(printString);
@@ -63,6 +67,7 @@ fast_copy(const uint8_t* src, const int src_stride, uint8_t* dst,
 }
 
 
+#ifdef _WIN32
 enum {
     CPU_NO_X86_SIMD          = 0x000000,
     CPU_SSE2_SUPPORT         = 0x000001,
@@ -188,4 +193,5 @@ bool has_avx2() noexcept
     uint32_t flags = CPU_AVX2_SUPPORT | CPU_FMA3_SUPPORT;
     return (get_simd_support_info() & flags) == flags;
 }
+#endif
 

--- a/src/win_import_min.h
+++ b/src/win_import_min.h
@@ -1,0 +1,48 @@
+
+#ifndef WIN_IMPORT_MIN_H
+#define WIN_IMPORT_MIN_H
+
+#define __int64                      int64_t
+
+#define __fastcall                   __attribute__((fastcall))
+
+/* support from recent _mingw.h */
+
+#include <limits.h>
+
+#define MAX_PATH                     PATH_MAX
+#define _MAX_PATH                    PATH_MAX
+
+#ifdef __cplusplus
+#define __forceinline inline __attribute__((__always_inline__))
+#else
+#define __forceinline extern __inline__ __attribute__((__always_inline__,__gnu_inline__))
+#endif /* __cplusplus */
+
+#ifdef __GNUC__
+#define _byteswap_ulong(x)           __builtin_bswap32(x)
+#endif
+
+#define _read                        read
+#define _lseeki64                    lseek
+#define _close                       close
+#define OutputDebugString(x)         fprintf(stderr,x)
+
+/* gnu libc offers the equivalent 'aligned_alloc' BUT requested 'size'
+   has to be a multiple of 'alignment' - in case it isn't, I'll set
+   a different size, rounding up the value */
+#define _aligned_malloc(s,a)         (                               \
+                                     aligned_alloc(a,((s-1)/a+1)*a)  \
+                                     )
+
+#define _aligned_free(x)             free(x)
+
+#define _atoi64(x)                   strtoll(x,NULL,10)
+#define sprintf_s(buf,...)           snprintf((buf),sizeof(buf),__VA_ARGS__)
+#define strncpy_s(d,n,s,c)           strncpy(d,s,c)
+#define vsprintf_s(d,n,t,v)          vsprintf(d,t,v)
+#define sscanf_s(buf,...)            sscanf((buf),__VA_ARGS__)
+#define fscanf_s(f,t,...)            fscanf(f,t,__VA_ARGS__)
+
+#endif // WIN_IMPORT_MIN_H
+

--- a/src/yv12pict.cpp
+++ b/src/yv12pict.cpp
@@ -23,6 +23,9 @@
 
 #include <stdexcept>
 #include <malloc.h>
+#ifndef _WIN32
+#include "win_import_min.h"
+#endif
 #include "yv12pict.h"
 
 //#define ptr_t unsigned int


### PR DESCRIPTION
I applied a bunch of fixes in order to get the plugin build in my linux box, and it works great!
A CMakefile for easy build using cmake is included.

A few notes about this posix-compliant patch.

Code modifications:
1. the CMPEG2Decoder constructor has a new parameter, that is the actual bitmask for cpu flags: recent Avisynth releases can detect those at runtime, and so most part of misc.cpp is superflous.

Runtime modifications & parameters:
1. idct=0,1,2,3,5,6,7 behavior is identical
2. idct=4 causes some rare difference (+1, -1) in a few bytes (in my benchmark they were as few as 1 in 4 MB up to 1 in 1.5 MB)
3. info=1 causes the debug information to be printed on every frame; it is left-aligned, not centered tough.
4. info=2 causes the debug information to be printed on stderr. Quite huge, but still useful sometimes.

Any other options work as expected, as far I can see.